### PR TITLE
Recognize routes tagged with line=<mode> as related to <mode> transport

### DIFF
--- a/subway_structure.py
+++ b/subway_structure.py
@@ -467,7 +467,7 @@ class Route:
             return False
         if 'members' not in el:
             return False
-        if el['tags'].get('route') not in modes:
+        if all(el['tags'].get(tag) not in modes for tag in ('route', 'line')):
             return False
         for k in CONSTRUCTION_KEYS:
             if k in el['tags']:
@@ -610,7 +610,7 @@ class Route:
         self.ref = relation['tags'].get('ref', master_tags.get(
             'ref', relation['tags'].get('name', None)))
         self.name = relation['tags'].get('name', None)
-        self.mode = relation['tags']['route']
+        self.mode = relation['tags'].get('line', relation['tags']['route'])
         if 'colour' not in relation['tags'] and 'colour' not in master_tags and self.mode != 'tram':
             city.warn('Missing colour on a route', relation)
         try:
@@ -785,7 +785,8 @@ class RouteMaster:
             except ValueError:
                 self.colour = None
             self.network = Route.get_network(master)
-            self.mode = master['tags'].get('route_master', None)  # This tag is required, but okay
+            self.mode = master['tags'].get('line',
+                master['tags'].get('route_master', None))  # This tag is required, but okay
             self.name = master['tags'].get('name', None)
             self.interval = Route.get_interval(master['tags'])
             self.interval_from_master = self.interval is not None

--- a/subway_structure.py
+++ b/subway_structure.py
@@ -467,7 +467,7 @@ class Route:
             return False
         if 'members' not in el:
             return False
-        if all(el['tags'].get(tag) not in modes for tag in ('route', 'line')):
+        if el['tags'].get('line', el['tags']['route']) not in modes:
             return False
         for k in CONSTRUCTION_KEYS:
             if k in el['tags']:

--- a/subway_structure.py
+++ b/subway_structure.py
@@ -467,7 +467,7 @@ class Route:
             return False
         if 'members' not in el:
             return False
-        if el['tags'].get('line', el['tags']['route']) not in modes:
+        if el['tags'].get('line', el['tags'].get('route')) not in modes:
             return False
         for k in CONSTRUCTION_KEYS:
             if k in el['tags']:


### PR DESCRIPTION
Recently somebody retagged Berlin s-bahn routes from "route=light_rail" to "route=train + line=light_rail" tag combination. The scheme with "line" tag is supported by [JOSM validator](https://wiki.openstreetmap.org/wiki/JOSM/Plugins/Routes) and also is used by [some data consumers](https://wiki.openstreetmap.org/wiki/%C3%96pnvkarte). 

I suggest to take into account "line" tag in route/route_master relations when defining transport mode, giving precedence to "line" over "route" tag value.

Data analysis reveals that the "line" tag is sometimes randomly used in route relations as copy/replace for "ref", "name" or "from"-"to" tags or contains "line=regular" value (the latter occurs 6 times around the world though).