### PR TITLE
Fix Station and StopArea classes hashing and comparison

### DIFF
--- a/subway_structure.py
+++ b/subway_structure.py
@@ -225,14 +225,6 @@ class Station:
         return 'Station(id={}, modes={}, name={}, center={})'.format(
             self.id, ','.join(self.modes), self.name, self.center)
 
-    def __hash__(self):
-        return hash(self.__repr__())
-
-    def __eq__(self, other):
-        if isinstance(other, Station):
-            return self.id == other.id
-        return False
-
 
 class StopArea:
     @staticmethod
@@ -365,14 +357,6 @@ class StopArea:
     def __repr__(self):
         return 'StopArea(id={}, name={}, station={}, transfer={}, center={})'.format(
             self.id, self.name, self.station, self.transfer, self.center)
-
-    def __hash__(self):
-        return hash(self.__repr__())
-
-    def __eq__(self, other):
-        if isinstance(other, StopArea):
-            return self.id == other.id and self.station == other.station
-        return False
 
 
 class RouteStop:
@@ -1237,18 +1221,23 @@ def find_transfers(elements, cities):
                 el.get('tags', {}).get('public_transport') == 'stop_area_group'):
             stop_area_groups.append(el)
 
-    stations = defaultdict(set)  # el_id -> list of station objects
+    # A tuple(sa.id, sa.station is None) uniquely identifies a StopArea.
+    # We must ensure StopArea uniqueness since one stop_area relation may result in
+    # several StopArea instances at inter-city interchanges.
+    stop_area_ids = defaultdict(set)  # el_id -> set of tuples (sa.id, sa.station is None)
+    stop_area_objects = dict()  # tuple(sa.id, sa.station is None) -> one of StopArea instances
     for city in cities:
         for el, st in city.stations.items():
-            stations[el].update(st)
+            stop_area_ids[el].update((sa.id, sa.station is None) for sa in st)
+            stop_area_objects.update(((sa.id, sa.station is None), sa) for sa in st)
 
     for sag in stop_area_groups:
         transfer = set()
         for m in sag['members']:
             k = el_id(m)
-            if k not in stations:
+            if k not in stop_area_ids:
                 continue
-            transfer.update(stations[k])
+            transfer.update(stop_area_objects[sa_id] for sa_id in stop_area_ids[k])
         if len(transfer) > 1:
             transfers.append(transfer)
     return transfers


### PR DESCRIPTION
Overridden special methods __hash__ and __eq__ of Station and StopArea classes now violate the rule: if two objects are equal then their hashes must also be equal. This is confusing and yields unexpected results. This is a code snippet inspired by City.make_transfer() method:

``` python
seen_stop_areas = set()
stop_area = get_reference_to_existing_stop_area()
seen_stop_areas.add(stop_area)
stop_area in seen_stop_areas # True
stop_area.transfer = found_transfer_id
stop_area in seen_stop_areas # False. Unexpected!
```
I suggest to leave default objects hashing and comparison (based on Python id(obj)) and discard duplicate instances manually in places where it is really needed. Currently there is only one such place: in find_transfers() function which deals with inter-city interchanges, where we must keep in mind that one OSM stop_area/"bare station" produces several StopAreas - one for each City.

I have verified that after this change the generated yaml/json/html files don't change, aside from list item order where the order is not important.