### PR TITLE
Cache of good cities

### DIFF
--- a/checkers/common.py
+++ b/checkers/common.py
@@ -1,0 +1,129 @@
+import logging
+from itertools import chain
+
+
+def floats_eq(a, b):
+    return abs(b - a) < 1e-13
+
+
+def coords_eq(lon1, lat1, lon2, lat2):
+    return floats_eq(lon1, lon2) and floats_eq(lat1, lat2)
+
+
+def osm_id_comparator(el):
+    """This function is used as key for sorting lists of
+       OSM-originated objects
+    """
+    return (el['osm_type'], el['osm_id'])
+
+
+def compare_stops(stop0, stop1):
+    """Compares json of two stops in route"""
+    stop_keys = ('name', 'int_name', 'id', 'osm_id', 'osm_type')
+    stop0_props = tuple(stop0[k] for k in stop_keys)
+    stop1_props = tuple(stop1[k] for k in stop_keys)
+
+    if stop0_props != stop1_props:
+        logging.debug("Different stops properties: %s, %s",
+                      stop0_props, stop1_props)
+        return False
+
+    if not coords_eq(stop0['lon'], stop0['lat'],
+                     stop1['lon'], stop1['lat']):
+        logging.debug("Different stops coordinates: %s (%f, %f), %s (%f, %f)",
+                      stop0_props, stop0['lon'], stop0['lat'],
+                      stop1_props, stop1['lon'], stop1['lat'])
+        return False
+
+    entrances0 = sorted(stop0['entrances'], key=osm_id_comparator)
+    entrances1 = sorted(stop1['entrances'], key=osm_id_comparator)
+    if entrances0 != entrances1:
+        logging.debug("Different stop entrances")
+        return False
+
+    exits0 = sorted(stop0['exits'], key=osm_id_comparator)
+    exits1 = sorted(stop1['exits'], key=osm_id_comparator)
+    if exits0 != exits1:
+        logging.debug("Different stop exits")
+        return False
+
+    return True
+
+
+def compare_transfers(transfers0, transfers1):
+    """Compares two arrays of transfers of the form
+       [(stop1_uid, stop2_uid, time), ...]
+    """
+    if len(transfers0) != len(transfers1):
+        logging.debug("Different len(transfers): %d != %d",
+                      len(transfers0), len(transfers1))
+        return False
+
+    transfers0 = [tuple(t) if t[0] < t[1] else tuple([t[1], t[0], t[2]])
+                  for t in transfers0]
+    transfers1 = [tuple(t) if t[0] < t[1] else tuple([t[1], t[0], t[2]])
+                  for t in transfers1]
+
+    transfers0.sort()
+    transfers1.sort()
+
+    diff_cnt = 0
+    for tr0, tr1 in zip(transfers0, transfers1):
+        if tr0 != tr1:
+            if diff_cnt == 0:
+                logging.debug("First pair of different transfers: %s, %s",
+                              tr0, tr1)
+            diff_cnt += 1
+    if diff_cnt:
+        logging.debug("Different transfers number = %d", diff_cnt)
+        return False
+
+    return True
+
+
+def compare_networks(network0, network1):
+    if network0['agency_id'] != network1['agency_id']:
+        logging.debug("Different agency_id at route '%s'",
+                      network0['network'])
+        return False
+
+    route_ids0 = sorted(x['route_id'] for x in network0['routes'])
+    route_ids1 = sorted(x['route_id'] for x in network1['routes'])
+
+    if route_ids0 != route_ids1:
+        logging.debug("Different route_ids: %s != %s",
+                      route_ids0, route_ids1)
+        return False
+
+    routes0 = sorted(network0['routes'], key=lambda x: x['route_id'])
+    routes1 = sorted(network1['routes'], key=lambda x: x['route_id'])
+
+    # Keys to compare routes. 'name' key is omitted since RouteMaster
+    # can get its name from one of its Routes unpredictably.
+    route_keys = ('type', 'ref', 'colour', 'route_id')
+
+    for route0, route1 in zip(routes0, routes1):
+        route0_props = tuple(route0[k] for k in route_keys)
+        route1_props = tuple(route1[k] for k in route_keys)
+        if route0_props != route1_props:
+            logging.debug("Route props of '%s' are different: %s, %s",
+                          route0['route_id'], route0_props, route1_props)
+            return False
+
+        itineraries0 = sorted(route0['itineraries'],
+                              key=lambda x: tuple(chain(*x['stops'])))
+        itineraries1 = sorted(route1['itineraries'],
+                              key=lambda x: tuple(chain(*x['stops'])))
+
+        for itin0, itin1 in zip(itineraries0, itineraries1):
+            if itin0['interval'] != itin1['interval']:
+                logging.debug("Different interval: %d != %d at route %s '%s'",
+                              itin0['interval'], itin1['interval'],
+                              route0['route_id'], route0['name'])
+                return False
+            if itin0['stops'] != itin1['stops']:
+                logging.debug("Different stops at route %s '%s'",
+                              route0['route_id'], route0['name'])
+                return False
+
+    return True

--- a/checkers/common.py
+++ b/checkers/common.py
@@ -1,13 +1,18 @@
 import logging
+import math
+import functools
 from itertools import chain
 
 
-def floats_eq(a, b):
-    return abs(b - a) < 1e-13
+"""A coordinate of a station precision of which we must take into account
+is calculated as an average of somewhat 10 elements.
+Taking machine epsilon 1e-15, averaging 10 numbers with close magnitudes
+ensures relative precision of 1e-14."""
+coord_isclose = functools.partial(math.isclose, rel_tol=1e-14)
 
 
 def coords_eq(lon1, lat1, lon2, lat2):
-    return floats_eq(lon1, lon2) and floats_eq(lat1, lat2)
+    return coord_isclose(lon1, lon2) and coord_isclose(lat1, lat2)
 
 
 def osm_id_comparator(el):
@@ -59,10 +64,14 @@ def compare_transfers(transfers0, transfers1):
                       len(transfers0), len(transfers1))
         return False
 
-    transfers0 = [tuple(t) if t[0] < t[1] else tuple([t[1], t[0], t[2]])
-                  for t in transfers0]
-    transfers1 = [tuple(t) if t[0] < t[1] else tuple([t[1], t[0], t[2]])
-                  for t in transfers1]
+    transfers0 = [tuple([t[0], t[1], t[2]])
+                      if t[0] < t[1] else
+                  tuple([t[1], t[0], t[2]])
+                      for t in transfers0]
+    transfers1 = [tuple([t[0], t[1], t[2]])
+                      if t[0] < t[1] else
+                  tuple([t[1], t[0], t[2]])
+                      for t in transfers1]
 
     transfers0.sort()
     transfers1.sort()

--- a/checkers/compare_city_caches.py
+++ b/checkers/compare_city_caches.py
@@ -1,0 +1,159 @@
+"""This utility allows one to check equivalency of generated city caches
+   (defined by --cache command line parameter) of process_subways.py.
+
+   Due to unordered nature of sets/dicts, two runs of process_subways.py
+   even on the same input generate equivalent jsons,
+   which cannot be compared with 'diff' command. The compare_jsons() function
+   compares two city_cache.json taking into account possible shuffling of
+   dict items and items of some lists, as well as system-specific subtleties.
+   This utility is useful to ensure that code improvements which must not
+   affect the process_subways.py output really doesn't change it.
+"""
+
+import sys
+import json
+from itertools import chain
+
+
+def compare_jsons(cache0, cache1):
+
+    def floats_eq(a, b):
+        return abs(b - a) < 1e-13
+
+    def coords_eq(lon1, lat1, lon2, lat2):
+        return floats_eq(lon1, lon2) and floats_eq(lat1, lat2)
+
+    def osm_id_comparator(el):
+        return (el['osm_type'], el['osm_id'])
+
+    city_names0 = sorted(cache0.keys())
+    city_names1 = sorted(cache1.keys())
+
+    if city_names0 != city_names1:
+        print("Different list of city names!")
+        return False
+
+    for name in city_names0:
+        result0 = cache0[name]
+        result1 = cache1[name]
+
+        network0 = result0['network']
+        network1 = result1['network']
+
+        if network0['agency_id'] != network1['agency_id']:
+            print("Different agency_id:",
+                  network0['network'], network1['network'])
+            return False
+
+        # Keys to compare routes. 'name' key is omitted since RouteMaster
+        # can get its name from one of its Routes unpredictably.
+        route_keys = ('type', 'ref', 'colour', 'route_id')
+
+        route_ids0 = sorted(x['route_id'] for x in network0['routes'])
+        route_ids1 = sorted(x['route_id'] for x in network1['routes'])
+
+        if route_ids0 != route_ids1:
+            print("Different route_ids", route_ids0, route_ids1)
+            return False
+
+        routes0 = sorted(network0['routes'], key=lambda x: x['route_id'])
+        routes1 = sorted(network1['routes'], key=lambda x: x['route_id'])
+
+        for route0, route1 in zip(routes0, routes1):
+            route0_props = tuple(route0[k] for k in route_keys)
+            route1_props = tuple(route1[k] for k in route_keys)
+            if route0_props != route1_props:
+                print("Route props of ", route0['route_id'], route1['route_id'],
+                      "are different:", route0_props, route1_props)
+                return False
+
+            itineraries0 = sorted(route0['itineraries'],
+                                  key=lambda x: tuple(chain(*x['stops'])))
+            itineraries1 = sorted(route1['itineraries'],
+                                  key=lambda x: tuple(chain(*x['stops'])))
+
+            for itin0, itin1 in zip(itineraries0, itineraries1):
+                if itin0['interval'] != itin1['interval']:
+                    print("Different interval:",
+                          itin0['interval'], "!=", itin1['interval'],
+                          "at route", route0['name'],  route0['route_id'])
+                    return False
+                if itin0['stops'] != itin1['stops']:
+                    print("Different stops at route",
+                          route0['name'], route0['route_id'])
+                    return False
+
+        stop_ids0 = sorted(result0['stops'].keys())
+        stop_ids1 = sorted(result1['stops'].keys())
+        if stop_ids0 != stop_ids1:
+            print("Different stop_ids")
+            return False
+
+        stops0 = [v for k, v in sorted(result0['stops'].items())]
+        stops1 = [v for k, v in sorted(result1['stops'].items())]
+
+        for stop0, stop1 in zip(stops0, stops1):
+            stop0_props = tuple(stop0[k] for k in ('name', 'osm_id', 'osm_type'))
+            stop1_props = tuple(stop1[k] for k in ('name', 'osm_id', 'osm_type'))
+            if stop0_props != stop1_props:
+                print("Different stops properties:", stop0_props, stop1_props)
+                return False
+            if not coords_eq(stop0['lon'], stop0['lat'],
+                             stop1['lon'], stop1['lat']):
+                print("Different stops coordinates:",
+                      stop0_props, stop0['lon'], stop0['lat'],
+                      stop1_props, stop1['lon'], stop1['lat'])
+                return False
+
+            entrances0 = sorted(stop0['entrances'], key=osm_id_comparator)
+            entrances1 = sorted(stop1['entrances'], key=osm_id_comparator)
+            if entrances0 != entrances1:
+                print("Different stop entrances")
+                return False
+
+            exits0 = sorted(stop0['exits'], key=osm_id_comparator)
+            exits1 = sorted(stop1['exits'], key=osm_id_comparator)
+            if exits0 != exits1:
+                print("Different stop exits")
+                return False
+
+
+        if len(result0['transfers']) != len(result1['transfers']):
+            print("Different len(transfers):",
+                  len(result0['transfers']), len(result1['transfers']))
+            return False
+
+        transfers0 = [tuple(t) if t[0] < t[1] else tuple([t[1], t[0], t[2]])
+                          for t in result0['transfers']]
+        transfers1 = [tuple(t) if t[0] < t[1] else tuple([t[1], t[0], t[2]])
+                          for t in result1['transfers']]
+
+        transfers0.sort(key=lambda x: tuple(x))
+        transfers1.sort(key=lambda x: tuple(x))
+
+        diff_cnt = 0
+        for i, (tr0, tr1) in enumerate(zip(transfers0, transfers1)):
+            if tr0 != tr1:
+                if i == 0:
+                    print("First pair of different transfers", tr0, tr1)
+                diff_cnt += 1
+        if diff_cnt:
+            print("Different transfers number = ", diff_cnt)
+            return False
+
+    return True
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print("Usage: {} <cache1.json> <cache2.json>".format(sys.argv[0]))
+        sys.exit()
+
+    path0, path1 = sys.argv[1:3]
+
+    j0 = json.load(open(path0, encoding='utf-8'))
+    j1 = json.load(open(path1, encoding='utf-8'))
+
+    equal = compare_jsons(j0, j1)
+
+    print("The results are {}equal".format("" if equal else "NOT "))

--- a/checkers/compare_city_caches.py
+++ b/checkers/compare_city_caches.py
@@ -12,133 +12,37 @@
 
 import sys
 import json
-from itertools import chain
+import logging
+from common import compare_stops, compare_transfers, compare_networks
 
 
 def compare_jsons(cache0, cache1):
-
-    def floats_eq(a, b):
-        return abs(b - a) < 1e-13
-
-    def coords_eq(lon1, lat1, lon2, lat2):
-        return floats_eq(lon1, lon2) and floats_eq(lat1, lat2)
-
-    def osm_id_comparator(el):
-        return (el['osm_type'], el['osm_id'])
+    """Compares two city caches"""
 
     city_names0 = sorted(cache0.keys())
     city_names1 = sorted(cache1.keys())
-
     if city_names0 != city_names1:
-        print("Different list of city names!")
+        logging.debug("Different list of city names!")
         return False
 
     for name in city_names0:
-        result0 = cache0[name]
-        result1 = cache1[name]
-
-        network0 = result0['network']
-        network1 = result1['network']
-
-        if network0['agency_id'] != network1['agency_id']:
-            print("Different agency_id:",
-                  network0['network'], network1['network'])
+        city0 = cache0[name]
+        city1 = cache1[name]
+        if not compare_networks(city0['network'], city1['network']):
             return False
 
-        # Keys to compare routes. 'name' key is omitted since RouteMaster
-        # can get its name from one of its Routes unpredictably.
-        route_keys = ('type', 'ref', 'colour', 'route_id')
-
-        route_ids0 = sorted(x['route_id'] for x in network0['routes'])
-        route_ids1 = sorted(x['route_id'] for x in network1['routes'])
-
-        if route_ids0 != route_ids1:
-            print("Different route_ids", route_ids0, route_ids1)
-            return False
-
-        routes0 = sorted(network0['routes'], key=lambda x: x['route_id'])
-        routes1 = sorted(network1['routes'], key=lambda x: x['route_id'])
-
-        for route0, route1 in zip(routes0, routes1):
-            route0_props = tuple(route0[k] for k in route_keys)
-            route1_props = tuple(route1[k] for k in route_keys)
-            if route0_props != route1_props:
-                print("Route props of ", route0['route_id'], route1['route_id'],
-                      "are different:", route0_props, route1_props)
-                return False
-
-            itineraries0 = sorted(route0['itineraries'],
-                                  key=lambda x: tuple(chain(*x['stops'])))
-            itineraries1 = sorted(route1['itineraries'],
-                                  key=lambda x: tuple(chain(*x['stops'])))
-
-            for itin0, itin1 in zip(itineraries0, itineraries1):
-                if itin0['interval'] != itin1['interval']:
-                    print("Different interval:",
-                          itin0['interval'], "!=", itin1['interval'],
-                          "at route", route0['name'],  route0['route_id'])
-                    return False
-                if itin0['stops'] != itin1['stops']:
-                    print("Different stops at route",
-                          route0['name'], route0['route_id'])
-                    return False
-
-        stop_ids0 = sorted(result0['stops'].keys())
-        stop_ids1 = sorted(result1['stops'].keys())
+        stop_ids0 = sorted(city0['stops'].keys())
+        stop_ids1 = sorted(city1['stops'].keys())
         if stop_ids0 != stop_ids1:
-            print("Different stop_ids")
+            logging.debug("Different stop_ids")
             return False
-
-        stops0 = [v for k, v in sorted(result0['stops'].items())]
-        stops1 = [v for k, v in sorted(result1['stops'].items())]
-
+        stops0 = [v for k, v in sorted(city0['stops'].items())]
+        stops1 = [v for k, v in sorted(city1['stops'].items())]
         for stop0, stop1 in zip(stops0, stops1):
-            stop0_props = tuple(stop0[k] for k in ('name', 'osm_id', 'osm_type'))
-            stop1_props = tuple(stop1[k] for k in ('name', 'osm_id', 'osm_type'))
-            if stop0_props != stop1_props:
-                print("Different stops properties:", stop0_props, stop1_props)
-                return False
-            if not coords_eq(stop0['lon'], stop0['lat'],
-                             stop1['lon'], stop1['lat']):
-                print("Different stops coordinates:",
-                      stop0_props, stop0['lon'], stop0['lat'],
-                      stop1_props, stop1['lon'], stop1['lat'])
+            if not compare_stops(stop0, stop1):
                 return False
 
-            entrances0 = sorted(stop0['entrances'], key=osm_id_comparator)
-            entrances1 = sorted(stop1['entrances'], key=osm_id_comparator)
-            if entrances0 != entrances1:
-                print("Different stop entrances")
-                return False
-
-            exits0 = sorted(stop0['exits'], key=osm_id_comparator)
-            exits1 = sorted(stop1['exits'], key=osm_id_comparator)
-            if exits0 != exits1:
-                print("Different stop exits")
-                return False
-
-
-        if len(result0['transfers']) != len(result1['transfers']):
-            print("Different len(transfers):",
-                  len(result0['transfers']), len(result1['transfers']))
-            return False
-
-        transfers0 = [tuple(t) if t[0] < t[1] else tuple([t[1], t[0], t[2]])
-                          for t in result0['transfers']]
-        transfers1 = [tuple(t) if t[0] < t[1] else tuple([t[1], t[0], t[2]])
-                          for t in result1['transfers']]
-
-        transfers0.sort(key=lambda x: tuple(x))
-        transfers1.sort(key=lambda x: tuple(x))
-
-        diff_cnt = 0
-        for i, (tr0, tr1) in enumerate(zip(transfers0, transfers1)):
-            if tr0 != tr1:
-                if i == 0:
-                    print("First pair of different transfers", tr0, tr1)
-                diff_cnt += 1
-        if diff_cnt:
-            print("Different transfers number = ", diff_cnt)
+        if not compare_transfers(city0['transfers'], city1['transfers']):
             return False
 
     return True
@@ -149,6 +53,8 @@ if __name__ == "__main__":
         print("Usage: {} <cache1.json> <cache2.json>".format(sys.argv[0]))
         sys.exit()
 
+    logging.basicConfig(level=logging.DEBUG)
+
     path0, path1 = sys.argv[1:3]
 
     j0 = json.load(open(path0, encoding='utf-8'))
@@ -156,4 +62,4 @@ if __name__ == "__main__":
 
     equal = compare_jsons(j0, j1)
 
-    print("The results are {}equal".format("" if equal else "NOT "))
+    print("The city caches are {}equal".format("" if equal else "NOT "))

--- a/checkers/compare_json_outputs.py
+++ b/checkers/compare_json_outputs.py
@@ -12,129 +12,36 @@
 
 import sys
 import json
-from itertools import chain
+import logging
+from common import compare_stops, compare_transfers, compare_networks
 
 
 def compare_jsons(result0, result1):
-
-    def floats_eq(a, b):
-        return abs(b - a) < 1e-13
-
-    def coords_eq(lon1, lat1, lon2, lat2):
-        return floats_eq(lon1, lon2) and floats_eq(lat1, lat2)
-
-    def osm_id_comparator(el):
-        return (el['osm_type'], el['osm_id'])
+    """Compares two objects which are results of subway generation"""
 
     network_names0 = sorted([x['network'] for x in result0['networks']])
     network_names1 = sorted([x['network'] for x in result1['networks']])
-
     if network_names0 != network_names1:
-        print("Different list of network names!")
+        logging.debug("Different list of network names!")
         return False
-
     networks0 = sorted(result0['networks'], key=lambda x: x['network'])
     networks1 = sorted(result1['networks'], key=lambda x: x['network'])
-
-    # Keys to compare routes. 'name' key is omitted since RouteMaster
-    # can get its name from one of its Routes unpredictably.
-    route_keys = ('type', 'ref', 'colour', 'route_id')
-
     for network0, network1 in zip(networks0, networks1):
-        if network0['agency_id'] != network1['agency_id']:
-            print("Different agency_id:",
-                  network0['network'], network1['network'])
+        if not compare_networks(network0, network1):
             return False
-
-        route_ids0 = sorted(x['route_id'] for x in network0['routes'])
-        route_ids1 = sorted(x['route_id'] for x in network1['routes'])
-
-        if route_ids0 != route_ids1:
-            print("Different route_ids", route_ids0, route_ids1)
-            return False
-
-        routes0 = sorted(network0['routes'], key=lambda x: x['route_id'])
-        routes1 = sorted(network1['routes'], key=lambda x: x['route_id'])
-
-        for route0, route1 in zip(routes0, routes1):
-            route0_props = tuple(route0[k] for k in route_keys)
-            route1_props = tuple(route1[k] for k in route_keys)
-            if route0_props != route1_props:
-                print("Route props of ", route0['route_id'], route1['route_id'],
-                      "are different:", route0_props, route1_props)
-                return False
-
-            itineraries0 = sorted(route0['itineraries'],
-                                  key=lambda x: tuple(chain(*x['stops'])))
-            itineraries1 = sorted(route1['itineraries'],
-                                  key=lambda x: tuple(chain(*x['stops'])))
-
-            for itin0, itin1 in zip(itineraries0, itineraries1):
-                if itin0['interval'] != itin1['interval']:
-                    print("Different interval:",
-                          itin0['interval'], "!=",  itin1['interval'],
-                          "at route", route0['name'], route0['route_id'])
-                    return False
-                if itin0['stops'] != itin1['stops']:
-                    print("Different stops at route",
-                          route0['name'], route0['route_id'])
-                    return False
 
     stop_ids0 = sorted(x['id'] for x in result0['stops'])
     stop_ids1 = sorted(x['id'] for x in result1['stops'])
     if stop_ids0 != stop_ids1:
-        print("Different stop_ids")
+        logging.debug("Different stop_ids")
         return False
-
     stops0 = sorted(result0['stops'], key=lambda x: x['id'])
     stops1 = sorted(result1['stops'], key=lambda x: x['id'])
-
     for stop0, stop1 in zip(stops0, stops1):
-        stop0_props = tuple(stop0[k] for k in ('name', 'osm_id', 'osm_type'))
-        stop1_props = tuple(stop1[k] for k in ('name', 'osm_id', 'osm_type'))
-        if stop0_props != stop1_props:
-            print("Different stops properties:", stop0_props, stop1_props)
-            return False
-        if not coords_eq(stop0['lon'], stop0['lat'],
-                         stop1['lon'], stop1['lat']):
-            print("Different stops coordinates:",
-                  stop0_props, stop0['lon'], stop0['lat'],
-                  stop1_props, stop1['lon'], stop1['lat'])
+        if not compare_stops(stop0, stop1):
             return False
 
-        entrances0 = sorted(stop0['entrances'], key=osm_id_comparator)
-        entrances1 = sorted(stop1['entrances'], key=osm_id_comparator)
-        if entrances0 != entrances1:
-            print("Different stop entrances")
-            return False
-
-        exits0 = sorted(stop0['exits'], key=osm_id_comparator)
-        exits1 = sorted(stop1['exits'], key=osm_id_comparator)
-        if exits0 != exits1:
-            print("Different stop exits")
-            return False
-
-    if len(result0['transfers']) != len(result1['transfers']):
-        print("Different len(transfers):",
-              len(result0['transfers']), len(result1['transfers']))
-        return False
-
-    transfers0 = [tuple(t) if t[0] < t[1] else tuple([t[1], t[0], t[2]])
-                      for t in result0['transfers']]
-    transfers1 = [tuple(t) if t[0] < t[1] else tuple([t[1], t[0], t[2]])
-                      for t in result1['transfers']]
-
-    transfers0.sort(key=lambda x: tuple(x))
-    transfers1.sort(key=lambda x: tuple(x))
-
-    diff_cnt = 0
-    for i, (tr0, tr1) in enumerate(zip(transfers0, transfers1)):
-        if tr0 != tr1:
-            if i == 0:
-                print("First pair of different transfers", tr0, tr1)
-            diff_cnt += 1
-    if diff_cnt:
-        print("Different transfers number = ", diff_cnt)
+    if not compare_transfers(result0['transfers'], result1['transfers']):
         return False
 
     return True
@@ -144,6 +51,8 @@ if __name__ == "__main__":
     if len(sys.argv) != 3:
         print("Usage: {} <file1.json> <file2.json>".format(sys.argv[0]))
         sys.exit()
+
+    logging.basicConfig(level=logging.DEBUG)
 
     path0, path1 = sys.argv[1:3]
 

--- a/checkers/compare_json_outputs.py
+++ b/checkers/compare_json_outputs.py
@@ -72,12 +72,12 @@ def compare_jsons(result0, result1):
             for itin0, itin1 in zip(itineraries0, itineraries1):
                 if itin0['interval'] != itin1['interval']:
                     print("Different interval:",
-                          f"{itin0['interval']} != {itin1['interval']}"
-                          f" at route {route0['name']} {route0['route_id']}")
+                          itin0['interval'], "!=",  itin1['interval'],
+                          "at route", route0['name'], route0['route_id'])
                     return False
                 if itin0['stops'] != itin1['stops']:
-                    print(f"Different stops at route",
-                          f"{route0['name']} {route0['route_id']}")
+                    print("Different stops at route",
+                          route0['name'], route0['route_id'])
                     return False
 
     stop_ids0 = sorted(x['id'] for x in result0['stops'])

--- a/checkers/compare_json_outputs.py
+++ b/checkers/compare_json_outputs.py
@@ -18,7 +18,7 @@ from itertools import chain
 def compare_jsons(result0, result1):
 
     def floats_eq(a, b):
-        return abs(b - a) < 1e-14
+        return abs(b - a) < 1e-13
 
     def coords_eq(lon1, lat1, lon2, lat2):
         return floats_eq(lon1, lon2) and floats_eq(lat1, lat2)

--- a/process_subways.py
+++ b/process_subways.py
@@ -406,5 +406,5 @@ if __name__ == '__main__':
         json.dump(res, options.log)
 
     if options.output:
-        json.dump(processor.process(good_cities, transfers, options.cache),
+        json.dump(processor.process(cities, transfers, options.cache),
                   options.output, indent=1, ensure_ascii=False)

--- a/processors/mapsme.py
+++ b/processors/mapsme.py
@@ -40,6 +40,16 @@ class DummyCache:
         return method
 
 
+def _skip_if_not_used(func):
+    """Decorator to skip method execution under certain condition.
+    Relies on "is_used" object property."""
+    def inner(self, *args, **kwargs):
+        if not self.is_used:
+            return
+        return func(self, *args, **kwargs)
+    return inner
+
+
 class MapsmeCache:
     def __init__(self, cache_path, cities):
         if not cache_path:
@@ -80,14 +90,6 @@ class MapsmeCache:
                 return False
 
         return True
-
-    def _skip_if_not_used(func):
-        """Decorator to skip method execution under certain condition."""
-        def inner(self, *args, **kwargs):
-            if not self.is_used:
-                return
-            return func(self, *args, **kwargs)
-        return inner
 
     @_skip_if_not_used
     def provide_stops_and_networks(self, stops, networks):

--- a/processors/mapsme.py
+++ b/processors/mapsme.py
@@ -87,19 +87,20 @@ def process(cities, transfers, cache_name):
     networks = []
 
     good_cities = [c for c in cities if c.is_good()]
+    city_names = set(c.name for c in cities)
     good_city_names = set(c.name for c in good_cities)
     recovered_city_names = set()
 
-    for city_name, city_cached_data in cache.items():
-        if city_name in good_city_names:
-            continue
-        # TODO: get a network, stops and transfers from cache
-        city = [c for c in cities if c.name == city_name][0]
-        if is_cached_city_usable(city, city_cached_data):
-            stops.update(city_cached_data['stops'])
-            networks.append(city_cached_data['network'])
-            print("Taking {} from cache".format(city_name))
-            recovered_city_names.add(city.name)
+    # Try take bad cities from cache.
+    for city_name in (city_names - good_city_names):
+        if city_name in cache:
+            city_cached_data = cache[city_name]
+            city = [c for c in cities if c.name == city_name][0]
+            if is_cached_city_usable(city, city_cached_data):
+                stops.update(city_cached_data['stops'])
+                networks.append(city_cached_data['network'])
+                print("Taking {} from cache".format(city_name))
+                recovered_city_names.add(city.name)
 
     platform_nodes = {}
 

--- a/processors/mapsme.py
+++ b/processors/mapsme.py
@@ -243,7 +243,7 @@ def process(cities, transfers, cache_name):
 
     if cache_name:
         with open(cache_name, 'w', encoding='utf-8') as f:
-            json.dump(cache, f, indent=2, ensure_ascii=False)
+            json.dump(cache, f, ensure_ascii=False)
 
     m_transfers = [(stop1_uid, stop2_uid, transfer_time)
                    for (stop1_uid, stop2_uid), transfer_time in c_transfers.items()]

--- a/scripts/process_subways.sh
+++ b/scripts/process_subways.sh
@@ -71,7 +71,9 @@ QNODES="railway=station station=subway =light_rail =monorail railway=subway_entr
 # Running the validation
 
 VALIDATION="$TMPDIR/validation.json"
-"$PYTHON" "$SUBWAYS_PATH/process_subways.py" -q -x "$FILTERED_DATA" -l "$VALIDATION" ${MAPSME+-o "$MAPSME"} ${CITY+-c "$CITY"} ${DUMP+-d "$DUMP"} ${JSON+-j "$JSON"}
+"$PYTHON" "$SUBWAYS_PATH/process_subways.py" -q -x "$FILTERED_DATA" -l "$VALIDATION" ${MAPSME+-o "$MAPSME"}\
+    ${CITY+-c "$CITY"} ${DUMP+-d "$DUMP"} ${JSON+-j "$JSON"}\
+    ${ELEMENTS_CACHE+-i "$ELEMENTS_CACHE"} ${CITY_CACHE+--cache "$CITY_CACHE"}
 rm "$FILTERED_DATA"
 
 # Preparing HTML files

--- a/subway_structure.py
+++ b/subway_structure.py
@@ -23,7 +23,6 @@ RAILWAY_TYPES = set(('rail', 'light_rail', 'subway', 'narrow_gauge',
 CONSTRUCTION_KEYS = ('construction', 'proposed', 'construction:railway', 'proposed:railway')
 NOWHERE_STOP = (0, 0)  # too far away from any metro system
 
-transfers = []
 used_entrances = set()
 
 
@@ -1213,7 +1212,6 @@ class City:
 
 
 def find_transfers(elements, cities):
-    global transfers
     transfers = []
     stop_area_groups = []
     for el in elements:


### PR DESCRIPTION
The process_subways.py script has a command-line parameter "--cache" which is intended to point to a json file with successfully processed cities, but isn't implemented yet. This pull request contains some working and tested implementation, which is not complete though and needs discussion and improvement. More concrete, the implementation in this PR:
1) rejects cached city if any cached station is absent in current osm data, otherwise accepts the city;
2) does not cache transfers;
3) does not consider entrances.