### PR TITLE
Automatic recovery of broken station order in a route

### DIFF
--- a/process_subways.py
+++ b/process_subways.py
@@ -9,12 +9,6 @@ import time
 import urllib.parse
 import urllib.request
 from processors import processor
-
-from subway_structure import (
-    download_cities,
-    find_transfers,
-    get_unused_entrances_geojson,
-)
 from subway_io import (
     dump_yaml,
     load_xml,
@@ -22,7 +16,11 @@ from subway_io import (
     read_recovery_data,
     write_recovery_data,
 )
-
+from subway_structure import (
+    download_cities,
+    find_transfers,
+    get_unused_entrances_geojson,
+)
 
 def overpass_request(bboxes=None):
     query = '[out:json][timeout:1000];('
@@ -104,7 +102,7 @@ if __name__ == '__main__':
         logging.error('No cities to process')
         sys.exit(2)
 
-    # augment cities with recovery data
+    # Augment cities with recovery data
     recovery_data = None
     if options.recovery_path:
         recovery_data = read_recovery_data(options.recovery_path)

--- a/process_subways.py
+++ b/process_subways.py
@@ -82,9 +82,9 @@ if __name__ == '__main__':
     parser.add_argument('-o', '--output', type=argparse.FileType('w', encoding='utf-8'),
                         help='Processed metro systems output')
     parser.add_argument('--cache', help='Cache file name for processed data')
-    parser.add_argument('--recovery-path', help='Cache file name for error recovery')
+    parser.add_argument('-r', '--recovery-path', help='Cache file name for error recovery')
     parser.add_argument('-d', '--dump', help='Make a YAML file for a city data')
-    parser.add_argument('-j', '--json', help='Make a GeoJSON file for a city data')
+    parser.add_argument('-j', '--geojson', help='Make a GeoJSON file for a city data')
     parser.add_argument('--crude', action='store_true',
                         help='Do not use OSM railway geometry for GeoJSON')
     options = parser.parse_args()
@@ -180,17 +180,17 @@ if __name__ == '__main__':
         else:
             logging.error('Cannot dump %s cities at once', len(cities))
 
-    if options.json:
-        if os.path.isdir(options.json):
+    if options.geojson:
+        if os.path.isdir(options.geojson):
             for c in cities:
-                with open(os.path.join(options.dump, slugify(c.name) + '.geojson'),
+                with open(os.path.join(options.geojson, slugify(c.name) + '.geojson'),
                           'w', encoding='utf-8') as f:
                     json.dump(make_geojson(c, not options.crude), f)
         elif len(cities) == 1:
-            with open(options.json, 'w', encoding='utf-8') as f:
+            with open(options.geojson, 'w', encoding='utf-8') as f:
                 json.dump(make_geojson(cities[0], not options.crude), f)
         else:
-            logging.error('Cannot make a json of %s cities at once', len(cities))
+            logging.error('Cannot make a geojson of %s cities at once', len(cities))
 
     if options.log:
         res = []

--- a/process_subways.py
+++ b/process_subways.py
@@ -9,7 +9,6 @@ import time
 import urllib.parse
 import urllib.request
 from processors import processor
-from collections import OrderedDict
 
 from subway_structure import (
     download_cities,
@@ -17,8 +16,11 @@ from subway_structure import (
     get_unused_entrances_geojson,
 )
 from subway_io import (
+    dump_yaml,
+    load_xml,
+    make_geojson,
     read_recovery_data,
-    write_recovery_data
+    write_recovery_data,
 )
 
 
@@ -55,230 +57,6 @@ def multi_overpass(bboxes):
             time.sleep(5)
         result.append(overpass_request(bboxes[i:i+SLICE_SIZE]))
     return result
-
-
-def load_xml(f):
-    try:
-        from lxml import etree
-    except ImportError:
-        import xml.etree.ElementTree as etree
-
-    elements = []
-    nodes = {}
-    for event, element in etree.iterparse(f):
-        if element.tag in ('node', 'way', 'relation'):
-            el = {'type': element.tag, 'id': int(element.get('id'))}
-            if element.tag == 'node':
-                for n in ('lat', 'lon'):
-                    el[n] = float(element.get(n))
-                nodes[el['id']] = (el['lat'], el['lon'])
-            tags = {}
-            nd = []
-            members = []
-            for sub in element:
-                if sub.tag == 'tag':
-                    tags[sub.get('k')] = sub.get('v')
-                elif sub.tag == 'nd':
-                    nd.append(int(sub.get('ref')))
-                elif sub.tag == 'member':
-                    members.append({'type': sub.get('type'),
-                                    'ref': int(sub.get('ref')),
-                                    'role': sub.get('role', '')})
-            if tags:
-                el['tags'] = tags
-            if nd:
-                el['nodes'] = nd
-            if members:
-                el['members'] = members
-            elements.append(el)
-            element.clear()
-
-    # Now make centers, assuming relations go after ways
-    ways = {}
-    relations = {}
-    for el in elements:
-        if el['type'] == 'way' and 'nodes' in el:
-            center = [0, 0]
-            count = 0
-            for nd in el['nodes']:
-                if nd in nodes:
-                    center[0] += nodes[nd][0]
-                    center[1] += nodes[nd][1]
-                    count += 1
-            if count > 0:
-                el['center'] = {'lat': center[0]/count, 'lon': center[1]/count}
-                ways[el['id']] = (el['center']['lat'], el['center']['lon'])
-        elif el['type'] == 'relation' and 'members' in el:
-            center = [0, 0]
-            count = 0
-            for m in el['members']:
-                if m['type'] == 'node' and m['ref'] in nodes:
-                    center[0] += nodes[m['ref']][0]
-                    center[1] += nodes[m['ref']][1]
-                    count += 1
-                elif m['type'] == 'way' and m['ref'] in ways:
-                    center[0] += ways[m['ref']][0]
-                    center[1] += ways[m['ref']][1]
-                    count += 1
-            if count > 0:
-                el['center'] = {'lat': center[0]/count, 'lon': center[1]/count}
-                relations[el['id']] = (el['center']['lat'], el['center']['lon'])
-
-    # Iterating again, now filling relations that contain only relations
-    for el in elements:
-        if el['type'] == 'relation' and 'members' in el:
-            center = [0, 0]
-            count = 0
-            for m in el['members']:
-                if m['type'] == 'node' and m['ref'] in nodes:
-                    center[0] += nodes[m['ref']][0]
-                    center[1] += nodes[m['ref']][1]
-                    count += 1
-                elif m['type'] == 'way' and m['ref'] in ways:
-                    center[0] += ways[m['ref']][0]
-                    center[1] += ways[m['ref']][1]
-                    count += 1
-                elif m['type'] == 'relation' and m['ref'] in relations:
-                    center[0] += relations[m['ref']][0]
-                    center[1] += relations[m['ref']][1]
-                    count += 1
-            if count > 0:
-                el['center'] = {'lat': center[0]/count, 'lon': center[1]/count}
-                relations[el['id']] = (el['center']['lat'], el['center']['lon'])
-    return elements
-
-
-def dump_data(city, f):
-    def write_yaml(data, f, indent=''):
-        if isinstance(data, (set, list)):
-            f.write('\n')
-            for i in data:
-                f.write(indent)
-                f.write('- ')
-                write_yaml(i, f, indent + '  ')
-        elif isinstance(data, dict):
-            f.write('\n')
-            for k, v in data.items():
-                if v is None:
-                    continue
-                f.write(indent + str(k) + ': ')
-                write_yaml(v, f, indent + '  ')
-                if isinstance(v, (list, set, dict)):
-                    f.write('\n')
-        else:
-            f.write(str(data))
-            f.write('\n')
-
-    INCLUDE_STOP_AREAS = False
-    stops = set()
-    routes = []
-    for route in city:
-        stations = OrderedDict([(sa.transfer or sa.id, sa.name) for sa in route.stop_areas()])
-        rte = {
-            'type': route.mode,
-            'ref': route.ref,
-            'name': route.name,
-            'colour': route.colour,
-            'infill': route.infill,
-            'station_count': len(stations),
-            'stations': list(stations.values()),
-            'itineraries': {}
-        }
-        for variant in route:
-            if INCLUDE_STOP_AREAS:
-                v_stops = []
-                for st in variant:
-                    s = st.stoparea
-                    if s.id == s.station.id:
-                        v_stops.append('{} ({})'.format(s.station.name, s.station.id))
-                    else:
-                        v_stops.append('{} ({}) in {} ({})'.format(s.station.name, s.station.id,
-                                                                   s.name, s.id))
-            else:
-                v_stops = ['{} ({})'.format(
-                    s.stoparea.station.name,
-                    s.stoparea.station.id) for s in variant]
-            rte['itineraries'][variant.id] = v_stops
-            stops.update(v_stops)
-        routes.append(rte)
-    transfers = []
-    for t in city.transfers:
-        v_stops = ['{} ({})'.format(s.name, s.id) for s in t]
-        transfers.append(v_stops)
-
-    result = {
-        'stations': sorted(stops),
-        'transfers': sorted(transfers, key=lambda t: t[0]),
-        'routes': sorted(routes, key=lambda r: r['ref']),
-    }
-    write_yaml(result, f)
-
-
-def make_geojson(city, tracks=True):
-    transfers = set()
-    for t in city.transfers:
-        transfers.update(t)
-    features = []
-    stopareas = set()
-    stops = set()
-    for rmaster in city:
-        for variant in rmaster:
-            if not tracks:
-                features.append({
-                    'type': 'Feature',
-                    'geometry': {
-                        'type': 'LineString',
-                        'coordinates': [s.stop for s in variant],
-                    },
-                    'properties': {
-                        'ref': variant.ref,
-                        'name': variant.name,
-                        'stroke': variant.colour
-                    }
-                })
-            elif variant.tracks:
-                features.append({
-                    'type': 'Feature',
-                    'geometry': {
-                        'type': 'LineString',
-                        'coordinates': variant.tracks,
-                    },
-                    'properties': {
-                        'ref': variant.ref,
-                        'name': variant.name,
-                        'stroke': variant.colour
-                    }
-                })
-            for st in variant:
-                stops.add(st.stop)
-                stopareas.add(st.stoparea)
-
-    for stop in stops:
-        features.append({
-            'type': 'Feature',
-            'geometry': {
-                'type': 'Point',
-                'coordinates': stop,
-            },
-            'properties': {
-                'marker-size': 'small',
-                'marker-symbol': 'circle'
-            }
-        })
-    for stoparea in stopareas:
-        features.append({
-            'type': 'Feature',
-            'geometry': {
-                'type': 'Point',
-                'coordinates': stoparea.center,
-            },
-            'properties': {
-                'name': stoparea.name,
-                'marker-size': 'small',
-                'marker-color': '#ff2600' if stoparea in transfers else '#797979'
-            }
-        })
-    return {'type': 'FeatureCollection', 'features': features}
 
 
 def slugify(name):
@@ -381,7 +159,8 @@ if __name__ == '__main__':
     logging.info('Finding transfer stations')
     transfers = find_transfers(osm, cities)
 
-    logging.info('%s good cities: %s', len(good_cities), ', '.join([c.name for c in good_cities]))
+    logging.info('%s good cities: %s', len(good_cities),
+                 ', '.join(sorted([c.name for c in good_cities])))
 
     if options.recovery_path:
         write_recovery_data(options.recovery_path, recovery_data, cities)
@@ -394,10 +173,10 @@ if __name__ == '__main__':
             for c in cities:
                 with open(os.path.join(options.dump, slugify(c.name) + '.yaml'),
                           'w', encoding='utf-8') as f:
-                    dump_data(c, f)
+                    dump_yaml(c, f)
         elif len(cities) == 1:
             with open(options.dump, 'w', encoding='utf-8') as f:
-                dump_data(cities[0], f)
+                dump_yaml(cities[0], f)
         else:
             logging.error('Cannot dump %s cities at once', len(cities))
 

--- a/processors/mapsme.py
+++ b/processors/mapsme.py
@@ -2,7 +2,10 @@ import json
 import os
 import logging
 from collections import defaultdict
-from subway_structure import distance, el_center, Station
+from subway_structure import (
+    distance, el_center, Station,
+    DISPLACEMENT_TOLERANCE
+)
 
 
 OSM_TYPES = {'n': (0, 'node'), 'w': (2, 'way'), 'r': (3, 'relation')}
@@ -13,7 +16,6 @@ SPEED_TO_ENTRANCE = 5 * KMPH_TO_MPS  # m/s
 SPEED_ON_TRANSFER = 3.5 * KMPH_TO_MPS  # m/s
 SPEED_ON_LINE = 40 * KMPH_TO_MPS  # m/s
 DEFAULT_INTERVAL = 2.5  # minutes
-DISPLACEMENT_TOLERANCE = 300  # meters
 
 
 def uid(elid, typ=None):

--- a/scripts/process_subways.sh
+++ b/scripts/process_subways.sh
@@ -72,8 +72,9 @@ QNODES="railway=station station=subway =light_rail =monorail railway=subway_entr
 
 VALIDATION="$TMPDIR/validation.json"
 "$PYTHON" "$SUBWAYS_PATH/process_subways.py" -q -x "$FILTERED_DATA" -l "$VALIDATION" ${MAPSME+-o "$MAPSME"}\
-    ${CITY+-c "$CITY"} ${DUMP+-d "$DUMP"} ${JSON+-j "$JSON"}\
-    ${ELEMENTS_CACHE+-i "$ELEMENTS_CACHE"} ${CITY_CACHE+--cache "$CITY_CACHE"}
+    ${CITY+-c "$CITY"} ${DUMP+-d "$DUMP"} ${GEOJSON+-j "$GEOJSON"}\
+    ${ELEMENTS_CACHE+-i "$ELEMENTS_CACHE"} ${CITY_CACHE+--cache "$CITY_CACHE"}\
+    ${RECOVERY_PATH+-r "$RECOVERY_PATH"}
 rm "$FILTERED_DATA"
 
 # Preparing HTML files

--- a/subway_io.py
+++ b/subway_io.py
@@ -279,7 +279,7 @@ def write_recovery_data(path, current_data, cities):
             route_id = (route.colour, route.ref)
             itineraries = []
             for variant in route:
-                itin = {'stops': [],
+                itin = {'stations': [],
                         'name': variant.name,
                         'from': variant.element['tags'].get('from'),
                         'to': variant.element['tags'].get('to')}
@@ -288,7 +288,7 @@ def write_recovery_data(path, current_data, cities):
                     station_name = station.name
                     if station_name == '?' and station.int_name:
                         station_name = station.int_name
-                    itin['stops'].append({
+                    itin['stations'].append({
                         'oms_id': station.id,
                         'name': station_name,
                         'center': station.center
@@ -312,5 +312,5 @@ def write_recovery_data(path, current_data, cities):
         with open(path, 'w', encoding='utf-8') as f:
             json.dump(data, f, ensure_ascii=False, indent=2)
     except Exception as e:
-        logging.warning("Cannot write recovery data '%s': %s", path, str(e))
+        logging.warning("Cannot write recovery data to '%s': %s", path, str(e))
 

--- a/subway_io.py
+++ b/subway_io.py
@@ -1,18 +1,244 @@
 import json
 import logging
+from collections import OrderedDict
+
+
+def load_xml(f):
+    try:
+        from lxml import etree
+    except ImportError:
+        import xml.etree.ElementTree as etree
+
+    elements = []
+    nodes = {}
+    for event, element in etree.iterparse(f):
+        if element.tag in ('node', 'way', 'relation'):
+            el = {'type': element.tag, 'id': int(element.get('id'))}
+            if element.tag == 'node':
+                for n in ('lat', 'lon'):
+                    el[n] = float(element.get(n))
+                nodes[el['id']] = (el['lat'], el['lon'])
+            tags = {}
+            nd = []
+            members = []
+            for sub in element:
+                if sub.tag == 'tag':
+                    tags[sub.get('k')] = sub.get('v')
+                elif sub.tag == 'nd':
+                    nd.append(int(sub.get('ref')))
+                elif sub.tag == 'member':
+                    members.append({'type': sub.get('type'),
+                                    'ref': int(sub.get('ref')),
+                                    'role': sub.get('role', '')})
+            if tags:
+                el['tags'] = tags
+            if nd:
+                el['nodes'] = nd
+            if members:
+                el['members'] = members
+            elements.append(el)
+            element.clear()
+
+    # Now make centers, assuming relations go after ways
+    ways = {}
+    relations = {}
+    for el in elements:
+        if el['type'] == 'way' and 'nodes' in el:
+            center = [0, 0]
+            count = 0
+            for nd in el['nodes']:
+                if nd in nodes:
+                    center[0] += nodes[nd][0]
+                    center[1] += nodes[nd][1]
+                    count += 1
+            if count > 0:
+                el['center'] = {'lat': center[0]/count, 'lon': center[1]/count}
+                ways[el['id']] = (el['center']['lat'], el['center']['lon'])
+        elif el['type'] == 'relation' and 'members' in el:
+            center = [0, 0]
+            count = 0
+            for m in el['members']:
+                if m['type'] == 'node' and m['ref'] in nodes:
+                    center[0] += nodes[m['ref']][0]
+                    center[1] += nodes[m['ref']][1]
+                    count += 1
+                elif m['type'] == 'way' and m['ref'] in ways:
+                    center[0] += ways[m['ref']][0]
+                    center[1] += ways[m['ref']][1]
+                    count += 1
+            if count > 0:
+                el['center'] = {'lat': center[0]/count, 'lon': center[1]/count}
+                relations[el['id']] = (el['center']['lat'], el['center']['lon'])
+
+    # Iterating again, now filling relations that contain only relations
+    for el in elements:
+        if el['type'] == 'relation' and 'members' in el:
+            center = [0, 0]
+            count = 0
+            for m in el['members']:
+                if m['type'] == 'node' and m['ref'] in nodes:
+                    center[0] += nodes[m['ref']][0]
+                    center[1] += nodes[m['ref']][1]
+                    count += 1
+                elif m['type'] == 'way' and m['ref'] in ways:
+                    center[0] += ways[m['ref']][0]
+                    center[1] += ways[m['ref']][1]
+                    count += 1
+                elif m['type'] == 'relation' and m['ref'] in relations:
+                    center[0] += relations[m['ref']][0]
+                    center[1] += relations[m['ref']][1]
+                    count += 1
+            if count > 0:
+                el['center'] = {'lat': center[0]/count, 'lon': center[1]/count}
+                relations[el['id']] = (el['center']['lat'], el['center']['lon'])
+    return elements
+
+
+def dump_yaml(city, f):
+    def write_yaml(data, f, indent=''):
+        if isinstance(data, (set, list)):
+            f.write('\n')
+            for i in data:
+                f.write(indent)
+                f.write('- ')
+                write_yaml(i, f, indent + '  ')
+        elif isinstance(data, dict):
+            f.write('\n')
+            for k, v in data.items():
+                if v is None:
+                    continue
+                f.write(indent + str(k) + ': ')
+                write_yaml(v, f, indent + '  ')
+                if isinstance(v, (list, set, dict)):
+                    f.write('\n')
+        else:
+            f.write(str(data))
+            f.write('\n')
+
+    INCLUDE_STOP_AREAS = False
+    stops = set()
+    routes = []
+    for route in city:
+        stations = OrderedDict([(sa.transfer or sa.id, sa.name) for sa in route.stop_areas()])
+        rte = {
+            'type': route.mode,
+            'ref': route.ref,
+            'name': route.name,
+            'colour': route.colour,
+            'infill': route.infill,
+            'station_count': len(stations),
+            'stations': list(stations.values()),
+            'itineraries': {}
+        }
+        for variant in route:
+            if INCLUDE_STOP_AREAS:
+                v_stops = []
+                for st in variant:
+                    s = st.stoparea
+                    if s.id == s.station.id:
+                        v_stops.append('{} ({})'.format(s.station.name, s.station.id))
+                    else:
+                        v_stops.append('{} ({}) in {} ({})'.format(s.station.name, s.station.id,
+                                                                   s.name, s.id))
+            else:
+                v_stops = ['{} ({})'.format(
+                    s.stoparea.station.name,
+                    s.stoparea.station.id) for s in variant]
+            rte['itineraries'][variant.id] = v_stops
+            stops.update(v_stops)
+        routes.append(rte)
+    transfers = []
+    for t in city.transfers:
+        v_stops = ['{} ({})'.format(s.name, s.id) for s in t]
+        transfers.append(v_stops)
+
+    result = {
+        'stations': sorted(stops),
+        'transfers': sorted(transfers, key=lambda t: t[0]),
+        'routes': sorted(routes, key=lambda r: r['ref']),
+    }
+    write_yaml(result, f)
+
+
+def make_geojson(city, tracks=True):
+    transfers = set()
+    for t in city.transfers:
+        transfers.update(t)
+    features = []
+    stopareas = set()
+    stops = set()
+    for rmaster in city:
+        for variant in rmaster:
+            if not tracks:
+                features.append({
+                    'type': 'Feature',
+                    'geometry': {
+                        'type': 'LineString',
+                        'coordinates': [s.stop for s in variant],
+                    },
+                    'properties': {
+                        'ref': variant.ref,
+                        'name': variant.name,
+                        'stroke': variant.colour
+                    }
+                })
+            elif variant.tracks:
+                features.append({
+                    'type': 'Feature',
+                    'geometry': {
+                        'type': 'LineString',
+                        'coordinates': variant.tracks,
+                    },
+                    'properties': {
+                        'ref': variant.ref,
+                        'name': variant.name,
+                        'stroke': variant.colour
+                    }
+                })
+            for st in variant:
+                stops.add(st.stop)
+                stopareas.add(st.stoparea)
+
+    for stop in stops:
+        features.append({
+            'type': 'Feature',
+            'geometry': {
+                'type': 'Point',
+                'coordinates': stop,
+            },
+            'properties': {
+                'marker-size': 'small',
+                'marker-symbol': 'circle'
+            }
+        })
+    for stoparea in stopareas:
+        features.append({
+            'type': 'Feature',
+            'geometry': {
+                'type': 'Point',
+                'coordinates': stoparea.center,
+            },
+            'properties': {
+                'name': stoparea.name,
+                'marker-size': 'small',
+                'marker-color': '#ff2600' if stoparea in transfers else '#797979'
+            }
+        })
+    return {'type': 'FeatureCollection', 'features': features}
+
 
 
 def _dumps_route_id(route_id):
-    """Argument is a route_id that depends on route colour, ref. Name
-    can be taken from route_master or be route's own, don't take it.
-    (some of route attributes can be None). Functions makes it json-compatible -
-    dumps to a string."""
+    """Argument is a route_id that depends on route colour and ref. Name
+    can be taken from route_master or can be route's own, we don't take it
+    into consideration. Some of route attributes can be None. The function makes
+    route_id json-compatible - dumps it to a string."""
     return json.dumps(route_id, ensure_ascii=False)
 
 
 def _loads_route_id(route_id_dump):
     """Argument is a json-encoded identifier of a route.
-    FunReturn a tuple of"""
+    Return a tuple (colour, ref)."""
     return tuple(json.loads(route_id_dump))
 
 
@@ -49,25 +275,19 @@ def write_recovery_data(path, current_data, cities):
         routes = {}
         for route in city:
             # Recovery is based primarily on route/station names/refs.
-            # If route's name/ref/colour changes, the route won't be used.
+            # If route's ref/colour changes, the route won't be used.
             route_id = (route.colour, route.ref)
             itineraries = []
             for variant in route:
                 itin = {'stops': [],
-                        'is_circular': variant.is_circular,
                         'name': variant.name,
                         'from': variant.element['tags'].get('from'),
                         'to': variant.element['tags'].get('to')}
                 for stop in variant:
                     station = stop.stoparea.station
                     station_name = station.name
-                    if station_name == '?':
+                    if station_name == '?' and station.int_name:
                         station_name = station.int_name
-                    # If a station has no name, the itinerary won't be used.
-                    # But! If variant contains only one unnamed station, we can cope with it.
-                    # if station_name is None:
-                    #    itin = None
-                    #    break
                     itin['stops'].append({
                         'oms_id': station.id,
                         'name': station_name,
@@ -92,6 +312,5 @@ def write_recovery_data(path, current_data, cities):
         with open(path, 'w', encoding='utf-8') as f:
             json.dump(data, f, ensure_ascii=False, indent=2)
     except Exception as e:
-        logging.warning("Cannot write recovery data '%s'", path)
-        logging.warning(str(e))
+        logging.warning("Cannot write recovery data '%s': %s", path, str(e))
 

--- a/subway_io.py
+++ b/subway_io.py
@@ -1,0 +1,97 @@
+import json
+import logging
+
+
+def _dumps_route_id(route_id):
+    """Argument is a route_id that depends on route colour, ref. Name
+    can be taken from route_master or be route's own, don't take it.
+    (some of route attributes can be None). Functions makes it json-compatible -
+    dumps to a string."""
+    return json.dumps(route_id, ensure_ascii=False)
+
+
+def _loads_route_id(route_id_dump):
+    """Argument is a json-encoded identifier of a route.
+    FunReturn a tuple of"""
+    return tuple(json.loads(route_id_dump))
+
+
+def read_recovery_data(path):
+    """Recovery data is a json with data from previous transport builds.
+    It helps to recover cities from some errors, e.g. by resorting
+    shuffled stations in routes."""
+    data = None
+    try:
+        with open(path, 'r') as f:
+            try:
+                data = json.load(f)
+            except json.decoder.JSONDecodeError as e:
+                logging.warning("Cannot load recovery data: {}".format(e))
+    except FileNotFoundError:
+        logging.warning("Cannot find recovery data file '{}'".format(path))
+
+    if data is None:
+        logging.warning("Continue without recovery data.")
+        return {}
+    else:
+        data = {
+            city_name: {_loads_route_id(route_id): route_data
+                                 for route_id, route_data in routes.items()}
+                    for city_name, routes in data.items()
+        }
+        return data
+
+
+def write_recovery_data(path, current_data, cities):
+    """Updates recovery data with good cities data and writes to file."""
+
+    def make_city_recovery_data(city):
+        routes = {}
+        for route in city:
+            # Recovery is based primarily on route/station names/refs.
+            # If route's name/ref/colour changes, the route won't be used.
+            route_id = (route.colour, route.ref)
+            itineraries = []
+            for variant in route:
+                itin = {'stops': [],
+                        'is_circular': variant.is_circular,
+                        'name': variant.name,
+                        'from': variant.element['tags'].get('from'),
+                        'to': variant.element['tags'].get('to')}
+                for stop in variant:
+                    station = stop.stoparea.station
+                    station_name = station.name
+                    if station_name == '?':
+                        station_name = station.int_name
+                    # If a station has no name, the itinerary won't be used.
+                    # But! If variant contains only one unnamed station, we can cope with it.
+                    # if station_name is None:
+                    #    itin = None
+                    #    break
+                    itin['stops'].append({
+                        'oms_id': station.id,
+                        'name': station_name,
+                        'center': station.center
+                    })
+                if itin is not None:
+                    itineraries.append(itin)
+            routes[route_id] = itineraries
+        return routes
+
+    data = current_data
+    for city in cities:
+        if city.is_good():
+            data[city.name] = make_city_recovery_data(city)
+
+    try:
+        data = {
+            city_name: {_dumps_route_id(route_id): route_data
+                        for route_id, route_data in routes.items()}
+            for city_name, routes in data.items()
+        }
+        with open(path, 'w', encoding='utf-8') as f:
+            json.dump(data, f, ensure_ascii=False, indent=2)
+    except Exception as e:
+        logging.warning("Cannot write recovery data '%s'", path)
+        logging.warning(str(e))
+

--- a/subway_structure.py
+++ b/subway_structure.py
@@ -6,10 +6,8 @@ import urllib.request
 from css_colours import normalize_colour
 from collections import Counter, defaultdict
 
-#test
-SPREADSHEET_ID = '1pEmmocGYugSqzJ8-ihdE3PnnZ101UjifGPszijMo_pY'
-#work
-#SPREADSHEET_ID = '1-UHDzfBwHdeyFxgC5cE_MaNQotF3-Y0r1nW9IwpIEj8'
+
+SPREADSHEET_ID = '1-UHDzfBwHdeyFxgC5cE_MaNQotF3-Y0r1nW9IwpIEj8'
 MAX_DISTANCE_TO_ENTRANCES = 300  # in meters
 MAX_DISTANCE_STOP_TO_LINE = 50  # in meters
 ALLOWED_STATIONS_MISMATCH = 0.02   # part of total station count

--- a/subway_structure.py
+++ b/subway_structure.py
@@ -78,11 +78,12 @@ def project_on_line(p, line):
         # u is the position of projection of p point on line p1p2
         # regarding point p1 and (p2-p1) direction vector
         u = ((p[0] - p1[0])*dp[0] + (p[1] - p1[1])*dp[1]) / d2
-        res = (p1[0] + u * dp[0], p1[1] + u * dp[1])
+        res = (p1[0] + u*dp[0], p1[1] + u*dp[1])
         if res[0] < min(p1[0], p2[0]) or res[0] > max(p1[0], p2[0]):
             return None
         return res
-        """if not 0 <= u <= 1:
+        """ # TODO: test this condition and use it instead of current approach.
+        if not 0 <= u <= 1:
             return None
         return (p1[0] + u*dp[0], p1[1] + u*dp[1])
         """

--- a/subway_structure.py
+++ b/subway_structure.py
@@ -771,12 +771,16 @@ class Route:
                     self.city.error(msg, self.element)
 
     def try_resort_stops(self):
-        """Precondition: self.city.recovery_data is not None"""
+        """Precondition: self.city.recovery_data is not None.
+        Return success of station order recovering."""
         self_stops = {} # station name => RouteStop
         for stop in self.stops:
-            stop_name = stop.stoparea.station.name
+            station = stop.stoparea.station
+            stop_name = station.name
+            if stop_name == '?' and station.int_name:
+                stop_name = station.int_name
             # We won't programmatically recover routes with repeating stations:
-            # the end doesn't justify the means
+            # such cases are rare and deserves manual verification
             if stop_name in self_stops:
                 return False
             self_stops[stop_name] = stop
@@ -813,7 +817,6 @@ class Route:
                 return False
             matching_itinerary = matching_itineraries[0]
         self.stops = [self_stops[stop['name']] for stop in matching_itinerary['stops']]
-        print("Recovered order!")
         return True
 
     def __len__(self):
@@ -987,6 +990,7 @@ class City:
         self.stops_and_platforms = set()  # Set of stops and platforms el_id
         self.errors = []
         self.warnings = []
+        self.recovery_data = None
 
     def log_message(self, message, el):
         if el:


### PR DESCRIPTION
The idea is to save some information from good city routes into a file (defined by `--recovery-path` command line parameter of `process_subways.py`) to use it during next script runs to programmatically recover some errors. In this PR we save station names and order in routes into recovery file, and if next time errors _"Angle between stops is too narrow"_ appear, we try to recover wrong station order.

It's worth noting that this type of recovery cannot be covered by city cache. City cache works only if all station osm_ids have not been changed, and the cache represents outdated city state. The PR would recover a city in the following scenario: OSM users amend metro stations with entrances and name translations, then remove station node, set its tags onto a polygon, and add this new station object to the end of route relation member list.