### PR TITLE
Fix overpass request

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,12 @@ of metro maps.
 
 ## How To Validate
 
-* Download or update a planet file in o5m format (using `osmconvert` and `osmupdate`).
-* Use `osmfilter` to extract a portion of data for all subways.
+
+* Choose transport data source:
+  1. Download or update a planet file in o5m format (using `osmconvert` and `osmupdate`).
+     Run `osmfilter` to extract a portion of data for all subways. Or
+  2. If you don't specify `--xml` or `--source` option to the `process_subways.py` script
+     it tries to fetch data over [Overpass API](https://wiki.openstreetmap.org/wiki/Overpass_API). **Not suitable for whole planet or large countries.**
 * Run `process_subways.py` with appropriate set of command line arguments
   to build metro structures and receive a validation log.
 * Run `validation_to_html.py` on that log to create readable HTML tables.

--- a/process_subways.py
+++ b/process_subways.py
@@ -35,7 +35,8 @@ def overpass_request(overground, overpass_api, bboxes=None):
         query += '('
         for mode in modes:
             query += 'rel[route="{}"]{};'.format(mode, bbox_part)
-        query += ');rel(br)[type=route_master];'
+        query += ');'
+        query += 'rel(br)[type=route_master];'
         if not overground:
             query += 'node[railway=subway_entrance]{};'.format(bbox_part)
         query += 'rel[public_transport=stop_area]{};'.format(bbox_part)

--- a/process_subways.py
+++ b/process_subways.py
@@ -203,7 +203,7 @@ if __name__ == '__main__':
             v = c.get_validation_result()
             v['slug'] = slugify(c.name)
             res.append(v)
-        json.dump(res, options.log, ensure_ascii=False)
+        json.dump(res, options.log, indent=2, ensure_ascii=False)
 
     if options.output:
         json.dump(processor.process(cities, transfers, options.cache),

--- a/subway_structure.py
+++ b/subway_structure.py
@@ -19,10 +19,11 @@ DISALLOWED_ANGLE_BETWEEN_STOPS = 20  # in degrees
 # it is likely the same object
 DISPLACEMENT_TOLERANCE = 300  # in meters
 
-DEFAULT_MODES = set(('subway', 'light_rail'))
+MODES_RAPID = set(('subway', 'light_rail', 'monorail', 'train'))
+MODES_OVERGROUND = set(('tram', 'bus', 'trolleybus', 'aerialway', 'ferry'))
+DEFAULT_MODES_RAPID = set(('subway', 'light_rail'))
 DEFAULT_MODES_OVERGROUND = set(('tram',))  # TODO: bus and trolleybus?
-ALL_MODES = set(('subway', 'light_rail', 'monorail', 'train', 'tram',
-                 'bus', 'trolleybus', 'aerialway', 'ferry'))
+ALL_MODES = MODES_RAPID | MODES_OVERGROUND
 RAILWAY_TYPES = set(('rail', 'light_rail', 'subway', 'narrow_gauge',
                      'funicular', 'monorail', 'tram'))
 CONSTRUCTION_KEYS = ('construction', 'proposed', 'construction:railway', 'proposed:railway')
@@ -197,7 +198,7 @@ class Station:
         return set(modes)
 
     @staticmethod
-    def is_station(el, modes=DEFAULT_MODES):
+    def is_station(el, modes):
         # public_transport=station is too ambigous and unspecific to use,
         # so we expect for it to be backed by railway=station.
         if 'tram' in modes and el.get('tags', {}).get('railway') == 'tram_stop':
@@ -384,7 +385,7 @@ class RouteStop:
         self.seen_station = False
 
     @staticmethod
-    def get_member_type(el, role, modes=DEFAULT_MODES):
+    def get_member_type(el, role, modes):
         if StopArea.is_stop(el):
             return 'stop'
         elif StopArea.is_platform(el):
@@ -457,7 +458,7 @@ class RouteStop:
 class Route:
     """The longest route for a city with a unique ref."""
     @staticmethod
-    def is_route(el, modes=DEFAULT_MODES):
+    def is_route(el, modes):
         if el['type'] != 'relation' or el.get('tags', {}).get('type') != 'route':
             return False
         if 'members' not in el:
@@ -980,7 +981,7 @@ class City:
             if self.overground:
                 self.modes = DEFAULT_MODES_OVERGROUND
             else:
-                self.modes = DEFAULT_MODES
+                self.modes = DEFAULT_MODES_RAPID
         else:
             self.modes = set([x.strip() for x in networks[0].split(',')])
 

--- a/validation_to_html.py
+++ b/validation_to_html.py
@@ -82,7 +82,7 @@ def tmpl(s, data=None, **kwargs):
 
 EXPAND_OSM_TYPE = {'n': 'node', 'w': 'way', 'r': 'relation'}
 RE_SHORT = re.compile(r'([nwr])(\d+)')
-RE_FULL = re.compile(r'(node|way|relation) (\d+)')
+RE_FULL = re.compile(r'\b(node|way|relation) (\d+)')
 RE_COORDS = re.compile(r'\((-?\d+\.\d+), (-?\d+\.\d+)\)')
 
 
@@ -108,7 +108,7 @@ if len(sys.argv) < 2:
     sys.exit(1)
 
 with open(sys.argv[1], 'r') as f:
-    data = {c['name']: CityData(c) for c in json.load(f)}
+    data = {c['name']: CityData(c) for c in json.load(f, encoding='utf-8')}
 
 countries = {}
 continents = {}

--- a/validation_to_html.py
+++ b/validation_to_html.py
@@ -107,8 +107,8 @@ if len(sys.argv) < 2:
     print('Usage: {} <validation.log> [<target_directory>]'.format(sys.argv[0]))
     sys.exit(1)
 
-with open(sys.argv[1], 'r') as f:
-    data = {c['name']: CityData(c) for c in json.load(f, encoding='utf-8')}
+with open(sys.argv[1], 'r', encoding='utf-8') as f:
+    data = {c['name']: CityData(c) for c in json.load(f)}
 
 countries = {}
 continents = {}

--- a/validation_to_html.py
+++ b/validation_to_html.py
@@ -81,8 +81,8 @@ def tmpl(s, data=None, **kwargs):
 
 
 EXPAND_OSM_TYPE = {'n': 'node', 'w': 'way', 'r': 'relation'}
-RE_SHORT = re.compile(r'([nwr])(\d+)')
-RE_FULL = re.compile(r'\b(node|way|relation) (\d+)')
+RE_SHORT = re.compile(r'\b([nwr])(\d+)\b')
+RE_FULL = re.compile(r'\b(node|way|relation) (\d+)\b')
 RE_COORDS = re.compile(r'\((-?\d+\.\d+), (-?\d+\.\d+)\)')
 
 


### PR DESCRIPTION
Current overpass_request() function does not provide desirable effect in several aspects:
- when given a bbox, the output is missing route_master and stop_area_group relations as not having definite coordinates;
- it does not recurse deep enough to fetch all relation members with their members;
- some other minor errors. 

I've rewrite fetching transport data with overpass request and verified that it provides almost the same result as planet.o5m filtering. "Almost" clause results from the fact that the `out center;` overpass statement produces different values from our averaging procedure for multipolygons. The discrepancy concerns only some entrances because the heuristic being used to bind nearby entrances to a station is sensitive to feature positions.