### PR TITLE
Recover after 'Item is not in dataset' exception to continue validating other cities

### DIFF
--- a/process_subways.py
+++ b/process_subways.py
@@ -160,11 +160,12 @@ if __name__ == '__main__':
     for c in cities:
         try:
             c.extract_routes()
+        except CriticalValidationError as e:
+            logging.error("Critical validation error: %s", str(e))
+        else:
             c.validate()
             if c.is_good():
                 good_cities.append(c)
-        except CriticalValidationError as e:
-            logging.error("Critical validation error: %s", str(e))
 
     logging.info('Finding transfer stations')
     transfers = find_transfers(osm, cities)

--- a/process_subways.py
+++ b/process_subways.py
@@ -22,6 +22,7 @@ from subway_structure import (
     get_unused_entrances_geojson,
     MODES_OVERGROUND,
     MODES_RAPID,
+    StopperException,
 )
 
 
@@ -157,7 +158,10 @@ if __name__ == '__main__':
     logging.info('Building routes for each city')
     good_cities = []
     for c in cities:
-        c.extract_routes()
+        try:
+            c.extract_routes()
+        except StopperException as e:
+            logging.error("Critical validation error: %s", str(e))
         c.validate()
         if c.is_good():
             good_cities.append(c)

--- a/process_subways.py
+++ b/process_subways.py
@@ -17,12 +17,12 @@ from subway_io import (
     write_recovery_data,
 )
 from subway_structure import (
+    CriticalValidationError,
     download_cities,
     find_transfers,
     get_unused_entrances_geojson,
     MODES_OVERGROUND,
     MODES_RAPID,
-    StopperException,
 )
 
 
@@ -160,11 +160,11 @@ if __name__ == '__main__':
     for c in cities:
         try:
             c.extract_routes()
-        except StopperException as e:
+            c.validate()
+            if c.is_good():
+                good_cities.append(c)
+        except CriticalValidationError as e:
             logging.error("Critical validation error: %s", str(e))
-        c.validate()
-        if c.is_good():
-            good_cities.append(c)
 
     logging.info('Finding transfer stations')
     transfers = find_transfers(osm, cities)

--- a/subway_structure.py
+++ b/subway_structure.py
@@ -959,6 +959,8 @@ class RouteMaster:
 
 class City:
     def __init__(self, row, overground=False):
+        self.errors = []
+        self.warnings = []
         self.name = row[1]
         self.country = row[2]
         self.continent = row[3]
@@ -1006,8 +1008,6 @@ class City:
         self.transfers = []  # List of lists of stop areas
         self.station_ids = set()  # Set of stations' uid
         self.stops_and_platforms = set()  # Set of stops and platforms el_id
-        self.errors = []
-        self.warnings = []
         self.recovery_data = None
 
     def log_message(self, message, el):

--- a/subway_structure.py
+++ b/subway_structure.py
@@ -32,9 +32,9 @@ NOWHERE_STOP = (0, 0)  # too far away from any metro system
 used_entrances = set()
 
 
-class StopperException(Exception):
-    """Is thrown if a critical validation error occurs
-    that prevents further validation."""
+class CriticalValidationError(Exception):
+    """Is thrown if an error occurs
+    that prevents further validation of a city."""
 
 
 def el_id(el):
@@ -711,7 +711,7 @@ class Route:
                 if 'stop' in m['role'] or 'platform' in m['role']:
                     city.error('{} {} {} for route relation is not in the dataset'.format(
                         m['role'], m['type'], m['ref']), relation)
-                    raise StopperException(
+                    raise CriticalValidationError(
                         'Stop or platform {} {} in relation {} '
                         'is not in the dataset for {}'.format(
                             m['type'], m['ref'], relation['id'], city.name))

--- a/subway_structure.py
+++ b/subway_structure.py
@@ -32,6 +32,11 @@ NOWHERE_STOP = (0, 0)  # too far away from any metro system
 used_entrances = set()
 
 
+class StopperException(Exception):
+    """Is thrown if a critical validation error occurs
+    that prevents further validation."""
+
+
 def el_id(el):
     if not el:
         return None
@@ -706,9 +711,10 @@ class Route:
                 if 'stop' in m['role'] or 'platform' in m['role']:
                     city.error('{} {} {} for route relation is not in the dataset'.format(
                         m['role'], m['type'], m['ref']), relation)
-                    raise Exception('Stop or platform {} {} in relation {} '
-                                    'is not in the dataset for {}'.format(
-                                        m['type'], m['ref'], relation['id'], city.name))
+                    raise StopperException(
+                        'Stop or platform {} {} in relation {} '
+                        'is not in the dataset for {}'.format(
+                            m['type'], m['ref'], relation['id'], city.name))
                 continue
             el = city.elements[k]
             if 'tags' not in el:
@@ -1152,17 +1158,17 @@ class City:
             'name': self.name,
             'country': self.country,
             'continent': self.continent,
-            'stations_found': self.found_stations,
-            'transfers_found': self.found_interchanges,
-            'unused_entrances': self.unused_entrances,
-            'networks': self.found_networks,
+            'stations_found': getattr(self, 'found_stations', 0),
+            'transfers_found': getattr(self, 'found_interchanges', 0),
+            'unused_entrances': getattr(self, 'unused_entrances', 0),
+            'networks': getattr(self, 'found_networks', 0)
         }
         if not self.overground:
             result.update({
                 'subwayl_expected': self.num_lines,
                 'lightrl_expected': self.num_light_lines,
-                'subwayl_found': self.found_lines,
-                'lightrl_found': self.found_light_lines,
+                'subwayl_found': getattr(self, 'found_lines', 0),
+                'lightrl_found': getattr(self, 'found_light_lines', 0),
                 'stations_expected': self.num_stations,
                 'transfers_expected': self.num_interchanges,
             })
@@ -1174,10 +1180,10 @@ class City:
                 'trolleybusl_expected': self.num_trolleybus_lines,
                 'traml_expected': self.num_tram_lines,
                 'otherl_expected': self.num_other_lines,
-                'busl_found': self.found_bus_lines,
-                'trolleybusl_found': self.found_trolleybus_lines,
-                'traml_found': self.found_tram_lines,
-                'otherl_found': self.found_other_lines,
+                'busl_found': getattr(self, 'found_bus_lines', 0),
+                'trolleybusl_found': getattr(self, 'found_trolleybus_lines', 0),
+                'traml_found': getattr(self, 'found_tram_lines', 0),
+                'otherl_found': getattr(self, 'found_other_lines', 0)
             })
         result['warnings'] = self.warnings
         result['errors'] = self.errors


### PR DESCRIPTION
At present, if an 'Item is not in dataset' error occurs for a city, e.g. due to small BBOX, the preprocessor fails with an unhandled exception. I think, more justified would be to log the error for the city and to continue validation of other cities.