### PR TITLE
Improve shell script

### DIFF
--- a/scripts/process_subways.sh
+++ b/scripts/process_subways.sh
@@ -93,5 +93,7 @@ rm "$VALIDATION"
 
 if [ -n "${SERVER-}" ]; then
   scp -q ${SERVER_KEY+-i "$SERVER_KEY"} "$HTML_DIR"/* "$SERVER"
-  [ -n "${REMOVE_HTML-}" ] && rm -r "$HTML_DIR"
+  if [ -n "${REMOVE_HTML-}" ]; then
+    rm -r "$HTML_DIR"
+  fi
 fi

--- a/scripts/process_subways.sh
+++ b/scripts/process_subways.sh
@@ -58,7 +58,8 @@ if [ -n "${GIT_PULL-}" ]; then (
 PLANET_ABS="$(cd "$(dirname "$PLANET")"; pwd)/$(basename "$PLANET")"
 (
   cd "$OSMCTOOLS" # osmupdate requires osmconvert in a current directory
-  ./osmupdate --drop-author --out-o5m "$PLANET_ABS" ${BBOX+"-b=$BBOX"} "$PLANET_ABS.new.o5m" && mv "$PLANET_ABS.new.o5m" "$PLANET_ABS"
+  ./osmupdate --drop-author --out-o5m "$PLANET_ABS" ${BBOX+"-b=$BBOX"} "$PLANET_ABS.new.o5m"
+  mv "$PLANET_ABS.new.o5m" "$PLANET_ABS"
 )
 
 # Filtering it

--- a/scripts/process_subways.sh
+++ b/scripts/process_subways.sh
@@ -66,7 +66,7 @@ PLANET_ABS="$(cd "$(dirname "$PLANET")"; pwd)/$(basename "$PLANET")"
 FILTERED_DATA="$TMPDIR/subways.osm"
 QRELATIONS="route=subway =light_rail =monorail =train route_master=subway =light_rail =monorail =train public_transport=stop_area =stop_area_group"
 QNODES="railway=station station=subway =light_rail =monorail railway=subway_entrance subway=yes light_rail=yes monorail=yes train=yes"
-"$OSMCTOOLS/osmfilter" "$PLANET" --keep= --keep-relations="$QRELATIONS" --keep-nodes="$QNODES" --drop-author "-o=$FILTERED_DATA"
+"$OSMCTOOLS/osmfilter" "$PLANET" --keep= --keep-relations="$QRELATIONS" --keep-nodes="$QNODES" --drop-author -o="$FILTERED_DATA"
 
 # Running the validation
 

--- a/scripts/process_subways.sh
+++ b/scripts/process_subways.sh
@@ -58,7 +58,7 @@ if [ -n "${GIT_PULL-}" ]; then (
 PLANET_ABS="$(cd "$(dirname "$PLANET")"; pwd)/$(basename "$PLANET")"
 (
   cd "$OSMCTOOLS" # osmupdate requires osmconvert in a current directory
-  ./osmupdate --drop-author --out-o5m "$PLANET_ABS" ${BBOX+"-b=$BBOX"} "$PLANET_ABS.new.o5m" && mv "$PLANET_ABS.new.o5m" "$PLANET_ABS" || true
+  ./osmupdate --drop-author --out-o5m "$PLANET_ABS" ${BBOX+"-b=$BBOX"} "$PLANET_ABS.new.o5m" && mv "$PLANET_ABS.new.o5m" "$PLANET_ABS"
 )
 
 # Filtering it


### PR DESCRIPTION
Changes overview:

1) Stop `process_subways.sh` script if `osmupdate $PLANET` phase fails. Otherwise the rest of the script may work with corrupted planet file.

2) Rewrite a bash operator from `[ test ] && command` to `if [ test ]; then command; fi` because with the first syntax if the `test` fails then the whole script returns non-zero code which confuses encompassing script.