### PR TITLE
Fix city country split

### DIFF
--- a/render/js/metro.js
+++ b/render/js/metro.js
@@ -66,7 +66,9 @@ L.CitySelect = L.Control.extend({
                 }
 
                 for (var i = 0; i < cities.length; i++) {
-                    city_name = cities[i].split(',')[0];
+                    // Remove country name which follows last comma and doesn't contain commas itself
+                    var last_comma_index = cities[i].lastIndexOf(',');
+                    var city_name = cities[i].substring(0, last_comma_index);
                     content += '<option value="' + city_name + '">' + cities[i] + '</option>';
                 }
 

--- a/v2h_templates.py
+++ b/v2h_templates.py
@@ -158,7 +158,7 @@ COUNTRY_CITY = '''
 </div><div class="warnings">
 {warnings}
 </div>
-</td></td>
+</td></tr>
 '''
 
 COUNTRY_FOOTER = '''


### PR DESCRIPTION
The render uses a text file with lines of the form "City, Country". There occurred a problem with records like "Washington, D.C., USA" which were split incorrectly at the first comma. Assuming that a country name won't contain commas, the pull request rewrites "City, Country" line splitting to happen at the last comma.