### PR TITLE
Report more correct node as hole spot

### DIFF
--- a/subway_structure.py
+++ b/subway_structure.py
@@ -554,7 +554,7 @@ class Route:
                     # Store the track if it is long and clean it
                     if not warned_about_holes:
                         city.warn('Hole in route rails near node {}'.format(
-                            new_segment[0]), relation)
+                            track[-1]), relation)
                         warned_about_holes = True
                     if len(track) > len(last_track):
                         last_track = track


### PR DESCRIPTION
This resolves issue #73.

Lets consider a hole in rails (numbers denote nodes where rail ways touch):

1------2---3   (hole)   4---5----6

Currently the validator may report node 4 or node 5 as a hole spot, depending on actual way 4-5 direction: 4-->5 or 4<--5. Obviously, node 5 is misleading when reported as a problem spot, especially considering that way 4-5 can have significant length and many intermediate nodes.
I suggest to report the last node of already built track -- node 3 in the example: node 2 would never be reported (unless 2-3 is the first segment in a route).