### PR TITLE
Check actual stop/platform elements role in routes

### DIFF
--- a/subway_structure.py
+++ b/subway_structure.py
@@ -741,11 +741,11 @@ class Route:
                 continue
 
             is_under_construction = False
-            for k in CONSTRUCTION_KEYS:
-                if k in el['tags']:
-                    city.error('An under construction {} in route. Consider '
+            for ck in CONSTRUCTION_KEYS:
+                if ck in el['tags']:
+                    city.error('An under construction {} {} in route. Consider '
                                'setting \'inactive\' role or removing construction attributes'
-                               .format(m['role'] or 'feature'), el)
+                               .format(m['role'] or 'feature', k), relation)
                     is_under_construction = True
                     break
             if is_under_construction:

--- a/subway_structure.py
+++ b/subway_structure.py
@@ -663,6 +663,8 @@ class Route:
         seen_platforms = False
         repeat_pos = None
         for m in relation['members']:
+            if 'inactive' in m['role']:
+                continue
             k = el_id(m)
             if k in city.stations:
                 st_list = city.stations[k]
@@ -757,7 +759,7 @@ class Route:
                     city.error('{} {} {} is not connected to a station in route'.format(
                         actual_role, m['type'], m['ref']), relation)
                 elif not StopArea.is_track(el):
-                    city.error('Unrecognized member in route', el)
+                    city.error('Unauthorized member {} {} in route'.format(m['type'], m['ref']), relation)
         if not self.stops:
             city.error('Route has no stops', relation)
         elif len(self.stops) == 1:

--- a/subway_structure.py
+++ b/subway_structure.py
@@ -759,7 +759,7 @@ class Route:
                     city.error('{} {} {} is not connected to a station in route'.format(
                         actual_role, m['type'], m['ref']), relation)
                 elif not StopArea.is_track(el):
-                    city.error('Unauthorized member {} {} in route'.format(m['type'], m['ref']), relation)
+                    city.error('Unknown member type for {} {} in route'.format(m['type'], m['ref']), relation)
         if not self.stops:
             city.error('Route has no stops', relation)
         elif len(self.stops) == 1:


### PR DESCRIPTION
Resolves issue #85.

Having been run on all networks, the updated code revealed another 2 missed (not connected to a station) stops which were silently ignored before. Also stops/platforms with the following incorrect roles were warned: 'start', 'station', 'access', 'Bayrampaşa - Maltepe'; 'stop' for a platform and 'platform' for a stop_position. Also rails with public_transport=stop_position were detected.