### PR TITLE
Check members of a stop_area_group

### DIFF
--- a/subway_structure.py
+++ b/subway_structure.py
@@ -1082,6 +1082,18 @@ class City:
         transfer = set()
         for m in sag['members']:
             k = el_id(m)
+            el = self.elements.get(k)
+            if not el:
+                # A sag member may validly not belong to the city while
+                # the sag does - near the city bbox boundary
+                continue
+            if 'tags' not in el:
+                self.error('An untagged object {} in a stop_area_group'.format(k), sag)
+                continue
+            if (el['type'] != 'relation' or
+                    el['tags'].get('type') != 'public_transport' or
+                    el['tags'].get('public_transport') != 'stop_area'):
+                continue
             if k in self.stations:
                 stoparea = self.stations[k][0]
                 transfer.add(stoparea)


### PR DESCRIPTION
Currently, if a feature (say, subway_entrance) is a member of a stop_area which in turn is a member of a stop_area_group, and if the feature is also added to the stop_area_group, we get confusing error message 'Stop area {} belongs to multiple interchanges'. This PR proposes to check that all members of a stop_area_group are stop_areas.

Also, there is need to check whether a stop_area_group member is among the city's elements. A stop_area relation may belong to a stop_area_group inside a city and at the same time may not belong to the city itself - near the city bbox boundary or in case of empty stop_area.