### PR TITLE
Disallow railway=station tag on relations other than multipolygons

### DIFF
--- a/subway_structure.py
+++ b/subway_structure.py
@@ -1119,6 +1119,11 @@ class City:
         processed_stop_areas = set()
         for el in self.elements.values():
             if Station.is_station(el, self.modes):
+                # See PR https://github.com/mapsme/subways/pull/98 
+                if el['type'] == 'relation' and el['tags'].get('type') != 'multipolygon':
+                    self.error("A railway station cannot be a relation of type '{}'".format(
+                                      el['tags'].get('type')), el)
+                    continue
                 st = Station(el, self)
                 self.station_ids.add(st.id)
                 if st.id in self.stop_areas:


### PR DESCRIPTION
This PR disallows railway=station tag on relations other than multipolygons, in particular on stop_areas.

The point is that railway=station tag is sometimes put onto type=public_transport+public_transport=stop_area relations, which results in a subtle bug: city is validated as good or bad (with "platform/stop is not connected to a station in route" error) unpredictably, depending on order of osm elements in input dataset and traversal order of python dict container.

Below follow technical details.
Let there be an osm stop_area **sa** that contains a railway=station **s**, there is also railway=station tag on the stop_area (probably with _mode_ tag so that Station.is_station(**sa**) also evaluates to True), and stop_positions/platforms from **sa** are used in routes. Each railway=station object produces a StopArea class instance with id equal to id of the stop_area it belongs to, or with its own id if it doesn't belong to any stop_area. Thus, in our case there would be two StopArea instances:
StopArea(station=s, stop_area=sa, id=sa.id)
StopArea(station=sa, stop_area=None, id=sa.id)
Two StopAreas with the same id are not assumed by the preprocessor. In fact, only one is taken into account (due to _processed_stop_areas_ id-based memorization container). If StopArea(station=s) is created first, the validation succeeds, otherwise it fails.

The solution is to prevent a stop_area from being also a railway=station.