### PR TITLE
Check stops order on tracks

### DIFF
--- a/process_subways.py
+++ b/process_subways.py
@@ -256,7 +256,11 @@ if __name__ == '__main__':
         try:
             c.extract_routes()
         except CriticalValidationError as e:
-            logging.error("Critical validation error: %s", str(e))
+            logging.error("Critical validation error while processing %s: %s", c.name, str(e))
+            c.error(str(e))
+        except AssertionError as e:
+            logging.error("Validation logic error while processing %s: %s", c.name, str(e))
+            c.error("Validation logic error: {}".format(str(e)))
         else:
             c.validate()
             if c.is_good():


### PR DESCRIPTION
Resolves issue #74.

For the longest continuous line of rails in a route we now check that the projections of stations that are near those rails follow the rails in order. This verification is more trustful than checking angles of polyline composed of station centers but works only if the route rails are mapped and sorted quite good.

When included in the validation of the full list of metro networks on 8 oct 2020, this change has detected 11 problems in stop  order that were unseen by the validator before.